### PR TITLE
suggested patch for unknown special keys

### DIFF
--- a/Graphics/UI/GLUT/Callbacks/Window.hs
+++ b/Graphics/UI/GLUT/Callbacks/Window.hs
@@ -322,6 +322,7 @@ data SpecialKey
    | KeyNumLock
    | KeyBegin
    | KeyDelete
+   | KeyUnknown Int
    deriving ( Eq, Ord, Show )
 
 unmarshalSpecialKey :: CInt -> SpecialKey
@@ -350,7 +351,7 @@ unmarshalSpecialKey x
    | x == glut_KEY_NUM_LOCK = KeyNumLock
    | x == glut_KEY_BEGIN = KeyBegin
    | x == glut_KEY_DELETE = KeyDelete
-   | otherwise = error ("unmarshalSpecialKey: illegal value " ++ show x)
+   | otherwise = KeyUnknown (fromIntegral x)
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
I use haskell GL/GLUT for psychology experiments, and by pressing some random keys one user managed to crash my program with the message "unmarshalSpecialKey: illegal value 109".  Whether or not this is a key that should really be handled (I have no idea what the key actually was), I'd just like to ignore it. Since this is happening inside GLUT, I don't see a good way to catch and recover from such errors, so it would be nice if GLUT was more forgiving of them.  Other unmarshal functions should perhaps be changed similarly.  If you have another suggestion, I'm open to it.
