### PR TITLE
Compatibility with GHC 7.6.1

### DIFF
--- a/GLUT.cabal
+++ b/GLUT.cabal
@@ -150,7 +150,7 @@ library
    c-sources:
       cbits/HsGLUT.c
    if flag(split-base)
-      build-depends: base >= 3 && < 5, array >= 0.3 && < 0.5, containers >= 0.3 && < 0.5
+      build-depends: base >= 3 && < 5, array >= 0.3 && < 0.5, containers >= 0.3 && < 0.6
    else
       build-depends: base < 3
    build-depends: OpenGL == 2.5.*, OpenGLRaw == 1.2.*, StateVar == 1.0.*, Tensor == 1.0.*

--- a/Graphics/UI/GLUT/Initialization.hs
+++ b/Graphics/UI/GLUT/Initialization.hs
@@ -331,7 +331,7 @@ handleMultisampling :: [Int] -> DisplayMode -> ([Int], DisplayMode)
 handleMultisampling spps (WithSamplesPerPixel spp) = (spp : spps, Multisampling)
 handleMultisampling spps mode                      = (spps, mode)
 
-toBitfield :: (Bits b) => (a -> b) -> [a] -> b
+toBitfield :: (Bits b, Num b) => (a -> b) -> [a] -> b
 toBitfield marshal = foldl (.|.) 0 . map marshal
 
 -- | Contains 'True' if the /current display mode/ is supported, 'False'


### PR DESCRIPTION
Increased upper bounds on containers dependency and altered context to include Bits type class to also include Num (as Bits instances are no longer required to be Num instances.)
