### PR TITLE
Issue fix, now compiles under ghc 7.6.1

### DIFF
--- a/Graphics/UI/GLUT/Initialization.hs
+++ b/Graphics/UI/GLUT/Initialization.hs
@@ -331,8 +331,10 @@ handleMultisampling :: [Int] -> DisplayMode -> ([Int], DisplayMode)
 handleMultisampling spps (WithSamplesPerPixel spp) = (spp : spps, Multisampling)
 handleMultisampling spps mode                      = (spps, mode)
 
-toBitfield :: (Num b, Bits b) => (a -> b) -> [a] -> b
-toBitfield marshal = foldl (.|.) 0 . map marshal
+toBitfield :: (Bits b) => (a -> b) -> [a] -> b
+toBitfield marshal = foldl (.|.) zero . map marshal
+           where
+                zero = (bit 0) `xor` (bit 0)
 
 -- | Contains 'True' if the /current display mode/ is supported, 'False'
 -- otherwise.


### PR DESCRIPTION
 Fixed compile error in a hacky way (replaced 0 with (bit 0) (bit 0), now compiles under ghc 7.6.1
