### PR TITLE
Allow building with freeglut on Windows

### DIFF
--- a/GLUT.cabal
+++ b/GLUT.cabal
@@ -107,7 +107,7 @@ library
       cpp-options: "-DCALLCONV=ccall"
     cc-options: "-DUSE_GETPROCADDRESS"
     if flag(freeglut)
-      cpp-options: "-DUSE_FREEGLUT"
+      cc-options: "-DUSE_FREEGLUT"
       extra-libraries: freeglut
     else
       extra-libraries: glut32

--- a/GLUT.cabal
+++ b/GLUT.cabal
@@ -43,10 +43,16 @@ extra-source-files:
    examples/RedBook8/Chapter01/triangles.frag
    examples/RedBook8/Chapter01/triangles.vert
 
+flag freeglut
+  description:
+    When compiling under Windows, use the freeglut library.
+  default: False
+  manual:  True
+
 flag UseNativeWindowsLibraries
   description:
     When compiling under Windows, use the native libraries instead of e.g. the
-    ones coming with Cygwin.
+    ones coming with Cygwin or MSYS.
 
 flag BuildExamples
   description: Build various OpenGL/GLUT examples.
@@ -94,13 +100,17 @@ library
   ghc-options: -Wall
   if impl(ghc > 8)
     ghc-options: -Wcompat
-  if os(windows) && flag(UseNativeWindowsLibraries)
+  if os(windows) && (flag(freeglut) || flag(UseNativeWindowsLibraries))
     if arch(i386)
       cpp-options: "-DCALLCONV=stdcall"
     else
       cpp-options: "-DCALLCONV=ccall"
     cc-options: "-DUSE_GETPROCADDRESS"
-    extra-libraries: glut32
+    if flag(freeglut)
+      cpp-options: "-DUSE_FREEGLUT"
+      extra-libraries: freeglut
+    else
+      extra-libraries: glut32
   else
     cpp-options: "-DCALLCONV=ccall"
     cc-options: "-DUSE_DLSYM"

--- a/GLUT.cabal
+++ b/GLUT.cabal
@@ -43,12 +43,6 @@ extra-source-files:
    examples/RedBook8/Chapter01/triangles.frag
    examples/RedBook8/Chapter01/triangles.vert
 
-flag freeglut
-  description:
-    When compiling under Windows, use the freeglut library.
-  default: False
-  manual:  True
-
 flag UseNativeWindowsLibraries
   description:
     When compiling under Windows, use the native libraries instead of e.g. the
@@ -100,17 +94,12 @@ library
   ghc-options: -Wall
   if impl(ghc > 8)
     ghc-options: -Wcompat
-  if os(windows) && (flag(freeglut) || flag(UseNativeWindowsLibraries))
+  if os(windows) && flag(UseNativeWindowsLibraries)
     if arch(i386)
       cpp-options: "-DCALLCONV=stdcall"
     else
       cpp-options: "-DCALLCONV=ccall"
     cc-options: "-DUSE_GETPROCADDRESS"
-    if flag(freeglut)
-      cc-options: "-DUSE_FREEGLUT"
-      extra-libraries: freeglut
-    else
-      extra-libraries: glut32
   else
     cpp-options: "-DCALLCONV=ccall"
     cc-options: "-DUSE_DLSYM"

--- a/cbits/HsGLUT.c
+++ b/cbits/HsGLUT.c
@@ -85,16 +85,17 @@ hs_GLUT_getProcAddress(const char *name)
 
   if (firstTime) {
     firstTime = 0;
-#if defined(USE_FREEGLUT)
-    handle = LoadLibrary(TEXT("freeglut"));
+    handle = LoadLibrary(TEXT("glut32"));
+
+    // If glut32 isn't present, try freeglut instead
+    if (!handle) {
+      handle = LoadLibrary(TEXT("freeglut"));
+    }
 
     // The MinGW-w64 version of freeglut prefixes "lib" onto the DLL name
     if (!handle) {
       handle = LoadLibrary(TEXT("libfreeglut"));
     }
-#else
-    handle = LoadLibrary(TEXT("glut32"));
-#endif
   }
 
   return handle ? GetProcAddress(handle, name) : NULL;

--- a/cbits/HsGLUT.c
+++ b/cbits/HsGLUT.c
@@ -85,7 +85,15 @@ hs_GLUT_getProcAddress(const char *name)
 
   if (firstTime) {
     firstTime = 0;
+#if defined(USE_FREEGLUT)
+    handle = LoadLibrary(TEXT("freeglut"));
+    // The MinGW-w64 version of freeglut prefixes "lib" onto the DLL name
+    if (!handle) {
+        handle = LoadLibrary(TEXT("libfreeglut"));
+    }
+#else
     handle = LoadLibrary(TEXT("glut32"));
+#endif
   }
 
   return handle ? GetProcAddress(handle, name) : NULL;

--- a/cbits/HsGLUT.c
+++ b/cbits/HsGLUT.c
@@ -87,9 +87,10 @@ hs_GLUT_getProcAddress(const char *name)
     firstTime = 0;
 #if defined(USE_FREEGLUT)
     handle = LoadLibrary(TEXT("freeglut"));
+
     // The MinGW-w64 version of freeglut prefixes "lib" onto the DLL name
     if (!handle) {
-        handle = LoadLibrary(TEXT("libfreeglut"));
+      handle = LoadLibrary(TEXT("libfreeglut"));
     }
 #else
     handle = LoadLibrary(TEXT("glut32"));


### PR DESCRIPTION
Currently, this library can only be built on Windows using `glut32.dll`, which not all Windows users have (including myself). This adds a `-ffreeglut` option to `GLUT.cabal` which makes GHC look for an installation of `freeglut` instead of `glut32`. This should work with with Martin Payne's `freeglut` binaries (http://www.transmissionzero.co.uk/software/freeglut-devel/) as well as the MinGW-w64 flavor of `freeglut` that MSYS2 provides (via `pacman -S mingw-w64-$(uname -m)-freeglut`).