### PR TITLE
Make it possible to link against installed version of freeglut on OSX

### DIFF
--- a/cbits/HsGLUT.c
+++ b/cbits/HsGLUT.c
@@ -50,6 +50,8 @@ hs_GLUT_getProcAddress(const char *name)
 
 static const char* libNames[] = {
 #ifdef __APPLE__
+  /* Try to use freeglut, checking the LD_LIBRARY_PATH */
+  "libglut.dylib",
   /* Try public framework path first. */
   "/Library/Frameworks/GLUT.framework/GLUT",
   /* If the public path failed, try the system framework path. */


### PR DESCRIPTION
Adding the libglut.dylib path to the libNames and setting the
LD_LIBRARY_PATH should link against freeglut if it's installed.

If LD_LIBRARY_PATH isn't set and/or freeglut isn't installed, then the osx system installs of GLUT will still be used.

