### PR TITLE
Add a display mode for macOS's GLUT_3_2_CORE_PROFILE

### DIFF
--- a/src/Graphics/UI/GLUT/Initialization.hs
+++ b/src/Graphics/UI/GLUT/Initialization.hs
@@ -260,6 +260,9 @@ data DisplayMode
      -- ^ Select a window without any borders (/freeglut only/).
    | SRGBMode
      -- ^ Select an sRGB mode window (/freeglut only/).
+   | MacOSCore32Profile
+     -- ^ Select a window with support for OpenGL 3.2 core profile
+     -- (/macOS system GLUT only/).
    deriving ( Eq, Ord, Show )
 
 marshalDisplayMode :: DisplayMode -> CUInt
@@ -286,6 +289,7 @@ marshalDisplayMode m = case m of
    Captionless -> glut_CAPTIONLESS
    Borderless -> glut_BORDERLESS
    SRGBMode -> glut_SRGB
+   MacOSCore32Profile -> glut_3_2_CORE_PROFILE
 
 --------------------------------------------------------------------------------
 

--- a/src/Graphics/UI/GLUT/Raw/Tokens.hs
+++ b/src/Graphics/UI/GLUT/Raw/Tokens.hs
@@ -18,6 +18,9 @@ module Graphics.UI.GLUT.Raw.Tokens where
 import Foreign.C.Types ( CInt, CUInt )
 import Graphics.Rendering.OpenGL ( GLenum )
 
+glut_3_2_CORE_PROFILE :: CUInt
+glut_3_2_CORE_PROFILE = 0x0800
+
 glut_ACCUM :: CUInt
 glut_ACCUM = 0x0004
 


### PR DESCRIPTION
On macOS's system GLUT there's a display mode for using OpenGL 3.2 core profile which is exposed as a display mode constant. (I'm not sure if this should be exposed by default for all operating systems, but as a workaround freeglut's `Borderless` constant has the same value)